### PR TITLE
Fix missing "typedef" in definition of `enum pseudo_access_t`

### DIFF
--- a/pseudo_ipc.h
+++ b/pseudo_ipc.h
@@ -40,7 +40,7 @@ typedef struct {
 	char path[];
 } pseudo_msg_t;
 
-enum {
+typedef enum {
 	PSA_EXEC = 1,
 	PSA_WRITE = (PSA_EXEC << 1),
 	PSA_READ = (PSA_WRITE << 1),


### PR DESCRIPTION
Otherwise the compiler will generate a global variable named  `pseudo_access_t`, typed by the anonymous enum.